### PR TITLE
Take content type into account for language detection

### DIFF
--- a/spotter-core/src/main/java/com/github/sdorra/spotter/ContentTypeDetector.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/ContentTypeDetector.java
@@ -64,7 +64,8 @@ public class ContentTypeDetector {
      * @return {@link ContentType} of path
      */
     public ContentType detect(String path) {
-        return of(tika.detect(path), matchingStrategy.detect(path, EMPTY_CONTENT));
+        String contentType = tika.detect(path);
+        return of(contentType, matchingStrategy.detect(new LanguageDetectionContext(contentType, path, EMPTY_CONTENT)));
     }
 
     /**
@@ -76,7 +77,8 @@ public class ContentTypeDetector {
      * @return {@link ContentType} of path and content prefix
      */
     public ContentType detect(String path, byte[] contentPrefix) {
-        return of(tika.detect(contentPrefix, path), matchingStrategy.detect(path, contentPrefix));
+        String contentType = tika.detect(contentPrefix, path);
+        return of(contentType, matchingStrategy.detect(new LanguageDetectionContext(contentType, path, contentPrefix)));
     }
 
     private ContentType of(String contentType, Optional<Language> language) {

--- a/spotter-core/src/main/java/com/github/sdorra/spotter/ContentTypes.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/ContentTypes.java
@@ -33,11 +33,13 @@ public final class ContentTypes {
 
     private static final ContentTypeDetector PATH_BASED_DETECTOR = ContentTypeDetector.builder()
         .detection(LanguageDetection.FILENAME, LanguageDetection.EXTENSION)
-        .firstMatch();
+        .detection(LanguageDetection.CONTENT_TYPE_BOOST)
+        .bestEffortMatch();
 
     private static final ContentTypeDetector PATH_AND_CONTENT_BASED_DETECTOR = ContentTypeDetector.builder()
         .detection(LanguageDetection.VI_MODE, LanguageDetection.EMACS_MODE, LanguageDetection.SHEBANG)
         .detection(LanguageDetection.FILENAME, LanguageDetection.EXTENSION)
+        .detection(LanguageDetection.CONTENT_TYPE_BOOST)
         .bestEffortMatch();
 
     private ContentTypes(){}

--- a/spotter-core/src/main/java/com/github/sdorra/spotter/LanguageDetection.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/LanguageDetection.java
@@ -24,6 +24,7 @@
 
 package com.github.sdorra.spotter;
 
+import com.github.sdorra.spotter.internal.ContentTypeBoostLanguageDetectionStrategy;
 import com.github.sdorra.spotter.internal.EmacsModeLanguageDetectionStrategy;
 import com.github.sdorra.spotter.internal.ExtensionLanguageDetectionStrategy;
 import com.github.sdorra.spotter.internal.FilenameLanguageDetectionStrategy;
@@ -69,7 +70,9 @@ public enum LanguageDetection {
     /**
      * Uses the file extension to detect language of the content.
      */
-    EXTENSION(new ExtensionLanguageDetectionStrategy());
+    EXTENSION(new ExtensionLanguageDetectionStrategy()),
+
+    CONTENT_TYPE_BOOST(new ContentTypeBoostLanguageDetectionStrategy());
 
     private LanguageDetectionStrategy strategy;
 

--- a/spotter-core/src/main/java/com/github/sdorra/spotter/LanguageDetectionContext.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/LanguageDetectionContext.java
@@ -1,0 +1,70 @@
+package com.github.sdorra.spotter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Context for language detection.
+ */
+public class LanguageDetectionContext {
+
+    private final String contentType;
+    private final String path;
+    private final byte[] content;
+    private final Collection<Language> previouslyDetected;
+
+    public LanguageDetectionContext(String contentType, String path, byte[] content) {
+        this(contentType, path, content, Collections.emptyList());
+    }
+
+    private LanguageDetectionContext(String contentType, String path, byte[] content, Collection<Language> previouslyDetected) {
+        this.contentType = contentType;
+        this.path = path;
+        this.content = content;
+        this.previouslyDetected = previouslyDetected;
+    }
+
+    /**
+     * @return content type detected by content detection
+     */
+    public String getContentType() {
+        return contentType;
+    }
+
+    /**
+     * @return content path
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * return first few bytes of content
+     */
+    public byte[] getContent() {
+        return content;
+    }
+
+    /**
+     * @return languages detected by previous strategies
+     */
+    public Collection<Language> getPreviouslyDetected() {
+        return previouslyDetected;
+    }
+
+    /**
+     * Creates a copy of this context with the given languages added to the languages of this context.
+     * @return New context with additional languages.
+     */
+    public LanguageDetectionContext addLanguages(Collection<Language> additionalLanguages) {
+        if (additionalLanguages.isEmpty()) {
+            return this;
+        }
+        int overallSize = additionalLanguages.size() + previouslyDetected.size();
+        Collection<Language> joinedLanguages = new ArrayList<>(overallSize);
+        joinedLanguages.addAll(additionalLanguages);
+        joinedLanguages.addAll(this.previouslyDetected);
+        return new LanguageDetectionContext(this.contentType, path, content, joinedLanguages);
+    }
+}

--- a/spotter-core/src/main/java/com/github/sdorra/spotter/internal/BestEffortMatchingStrategy.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/internal/BestEffortMatchingStrategy.java
@@ -25,6 +25,7 @@
 package com.github.sdorra.spotter.internal;
 
 import com.github.sdorra.spotter.Language;
+import com.github.sdorra.spotter.LanguageDetectionContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,13 +45,14 @@ public class BestEffortMatchingStrategy implements MatchingStrategy {
     }
 
     @Override
-    public Optional<Language> detect(String path, byte[] content) {
+    public Optional<Language> detect(LanguageDetectionContext context) {
         List<Match> matches = new ArrayList<>();
 
         for (int i=0; i<strategies.length; i++) {
             LanguageDetectionStrategy strategy = strategies[i];
 
-            List<Language> languages = strategy.detect(path, content);
+            List<Language> languages = strategy.detect(context);
+            context = context.addLanguages(languages);
             for (Language language : languages) {
                 addMatch(matches, language, i);
             }

--- a/spotter-core/src/main/java/com/github/sdorra/spotter/internal/ContentTypeBoostLanguageDetectionStrategy.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/internal/ContentTypeBoostLanguageDetectionStrategy.java
@@ -1,0 +1,35 @@
+package com.github.sdorra.spotter.internal;
+
+import com.github.sdorra.spotter.Language;
+import com.github.sdorra.spotter.LanguageDetectionContext;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class ContentTypeBoostLanguageDetectionStrategy implements LanguageDetectionStrategy {
+
+    @Override
+    public List<Language> detect(LanguageDetectionContext context) {
+        MediaTypeMatcher matchesContentType = new MediaTypeMatcher(context.getContentType());
+        return context
+            .getPreviouslyDetected()
+            .stream()
+            .filter(matchesContentType)
+            .collect(Collectors.toList());
+    }
+
+    private static class MediaTypeMatcher implements Predicate<Language> {
+        private final String lowerCaseContentType;
+
+        private MediaTypeMatcher(String contentType) {
+            this.lowerCaseContentType = contentType.toLowerCase(Locale.ENGLISH);
+        }
+
+        @Override
+        public boolean test(Language language) {
+            return lowerCaseContentType.contains(language.getName().toLowerCase(Locale.ENGLISH));
+        }
+    }
+}

--- a/spotter-core/src/main/java/com/github/sdorra/spotter/internal/FilenameBasedLanguageDetectionStrategy.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/internal/FilenameBasedLanguageDetectionStrategy.java
@@ -26,6 +26,7 @@
 package com.github.sdorra.spotter.internal;
 
 import com.github.sdorra.spotter.Language;
+import com.github.sdorra.spotter.LanguageDetectionContext;
 
 import java.nio.file.Paths;
 import java.util.List;
@@ -36,8 +37,8 @@ import java.util.List;
 public abstract class FilenameBasedLanguageDetectionStrategy implements LanguageDetectionStrategy {
 
     @Override
-    public List<Language> detect(String path, byte[] content) {
-        String filename = Paths.get(path).getFileName().toString();
+    public List<Language> detect(LanguageDetectionContext context) {
+        String filename = Paths.get(context.getPath()).getFileName().toString();
         return detectByFilename(filename);
     }
 

--- a/spotter-core/src/main/java/com/github/sdorra/spotter/internal/FirstMatchMathingStrategy.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/internal/FirstMatchMathingStrategy.java
@@ -26,6 +26,7 @@
 package com.github.sdorra.spotter.internal;
 
 import com.github.sdorra.spotter.Language;
+import com.github.sdorra.spotter.LanguageDetectionContext;
 
 import java.util.List;
 import java.util.Optional;
@@ -48,9 +49,9 @@ public class FirstMatchMathingStrategy implements MatchingStrategy {
     }
 
     @Override
-    public Optional<Language> detect(String path, byte[] content) {
+    public Optional<Language> detect(LanguageDetectionContext context) {
         for (LanguageDetectionStrategy strategy : strategies) {
-            List<Language> lang = strategy.detect(path, content);
+            List<Language> lang = strategy.detect(context);
             if (!lang.isEmpty()) {
                 return Optional.of(lang.get(0));
             }

--- a/spotter-core/src/main/java/com/github/sdorra/spotter/internal/LanguageDetectionStrategy.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/internal/LanguageDetectionStrategy.java
@@ -26,6 +26,8 @@
 package com.github.sdorra.spotter.internal;
 
 import com.github.sdorra.spotter.Language;
+import com.github.sdorra.spotter.LanguageDetectionContext;
+
 import java.util.List;
 
 /**
@@ -36,10 +38,9 @@ public interface LanguageDetectionStrategy {
     /**
      * Detects possible languages of a path and or the content.
      *
-     * @param path content path
-     * @param content first few bytes of content
+     * @param context Context for the detection
      *
      * @return list of matching languages
      */
-    List<Language> detect(String path, byte[] content);
+    List<Language> detect(LanguageDetectionContext context);
 }

--- a/spotter-core/src/main/java/com/github/sdorra/spotter/internal/MatchingStrategy.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/internal/MatchingStrategy.java
@@ -25,11 +25,12 @@
 package com.github.sdorra.spotter.internal;
 
 import com.github.sdorra.spotter.Language;
+import com.github.sdorra.spotter.LanguageDetectionContext;
 
 import java.util.Optional;
 
 public interface MatchingStrategy {
 
-    Optional<Language> detect(String path, byte[] content);
+    Optional<Language> detect(LanguageDetectionContext context);
 
 }

--- a/spotter-core/src/main/java/com/github/sdorra/spotter/internal/StringContentBasedLanguageDetectionStrategy.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/internal/StringContentBasedLanguageDetectionStrategy.java
@@ -25,6 +25,7 @@
 package com.github.sdorra.spotter.internal;
 
 import com.github.sdorra.spotter.Language;
+import com.github.sdorra.spotter.LanguageDetectionContext;
 
 import java.util.List;
 
@@ -33,8 +34,8 @@ import java.util.List;
  */
 public abstract class StringContentBasedLanguageDetectionStrategy implements LanguageDetectionStrategy {
     @Override
-    public List<Language> detect(String path, byte[] content) {
-        return detectByContent(new String(content));
+    public List<Language> detect(LanguageDetectionContext context){
+        return detectByContent(new String(context.getContent()));
     }
 
     protected abstract List<Language> detectByContent(String content);

--- a/spotter-core/src/test/java/com/github/sdorra/spotter/ContentTypesTest.java
+++ b/spotter-core/src/test/java/com/github/sdorra/spotter/ContentTypesTest.java
@@ -29,10 +29,10 @@ import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ContentTypesTest {
 
@@ -49,6 +49,15 @@ public class ContentTypesTest {
         assertEquals("image/png", type.getRaw());
         assertFalse(type.isText());
         assertFalse(type.getLanguage().isPresent());
+    }
+
+    @Test
+    public void testDetectWithMarkdown() {
+        ContentType type = ContentTypes.detect("com/github/sdorra/scm-manager.md");
+        assertEquals("text/x-web-markdown", type.getRaw());
+        assertTrue(type.isText());
+        assertTrue(type.getLanguage().isPresent());
+        assertEquals(Language.MARKDOWN, type.getLanguage().get());
     }
 
     @Test

--- a/spotter-core/src/test/java/com/github/sdorra/spotter/internal/BestEffortMatchingStrategyTest.java
+++ b/spotter-core/src/test/java/com/github/sdorra/spotter/internal/BestEffortMatchingStrategyTest.java
@@ -25,6 +25,7 @@
 package com.github.sdorra.spotter.internal;
 
 import com.github.sdorra.spotter.Language;
+import com.github.sdorra.spotter.LanguageDetectionContext;
 import org.junit.Test;
 
 import java.util.Optional;
@@ -39,7 +40,7 @@ public class BestEffortMatchingStrategyTest {
         LanguageDetectionStrategy one = noopDetectionStrategy(Language.JAVASCRIPT);
         BestEffortMatchingStrategy strategy = new BestEffortMatchingStrategy(one);
 
-        Optional<Language> language = strategy.detect("/some/path", new byte[0]);
+        Optional<Language> language = strategy.detect(new LanguageDetectionContext("", "/some/path", new byte[0]));
         assertThat(language).contains(Language.JAVASCRIPT);
     }
 
@@ -49,7 +50,7 @@ public class BestEffortMatchingStrategyTest {
         LanguageDetectionStrategy two = noopDetectionStrategy(Language.JAVASCRIPT);
         BestEffortMatchingStrategy strategy = new BestEffortMatchingStrategy(one, two);
 
-        Optional<Language> language = strategy.detect("/some/path", new byte[0]);
+        Optional<Language> language = strategy.detect(new LanguageDetectionContext("", "/some/path", new byte[0]));
         assertThat(language).contains(Language.JAVASCRIPT);
     }
 
@@ -60,7 +61,7 @@ public class BestEffortMatchingStrategyTest {
         LanguageDetectionStrategy three = noopDetectionStrategy(Language.TYPESCRIPT);
         BestEffortMatchingStrategy strategy = new BestEffortMatchingStrategy(one, two, three);
 
-        Optional<Language> language = strategy.detect("/some/path", new byte[0]);
+        Optional<Language> language = strategy.detect(new LanguageDetectionContext("", "/some/path", new byte[0]));
         assertThat(language).contains(Language.JAVASCRIPT);
     }
 
@@ -70,7 +71,7 @@ public class BestEffortMatchingStrategyTest {
         LanguageDetectionStrategy two = noopDetectionStrategy();
         BestEffortMatchingStrategy strategy = new BestEffortMatchingStrategy(one, two);
 
-        Optional<Language> language = strategy.detect("/some/path", new byte[0]);
+        Optional<Language> language = strategy.detect(new LanguageDetectionContext("", "/some/path", new byte[0]));
         assertThat(language).isEmpty();
     }
 

--- a/spotter-core/src/test/java/com/github/sdorra/spotter/internal/FirstMatchMathingStrategyTest.java
+++ b/spotter-core/src/test/java/com/github/sdorra/spotter/internal/FirstMatchMathingStrategyTest.java
@@ -25,6 +25,7 @@
 package com.github.sdorra.spotter.internal;
 
 import com.github.sdorra.spotter.Language;
+import com.github.sdorra.spotter.LanguageDetectionContext;
 import org.junit.Test;
 
 import java.util.Optional;
@@ -39,7 +40,7 @@ public class FirstMatchMathingStrategyTest {
         LanguageDetectionStrategy languageDetectionStrategy = noopDetectionStrategy(Language.JAVA);
         FirstMatchMathingStrategy mathingStrategy = new FirstMatchMathingStrategy(languageDetectionStrategy);
 
-        Optional<Language> language = mathingStrategy.detect("/some/file", new byte[0]);
+        Optional<Language> language = mathingStrategy.detect(new LanguageDetectionContext("", "/some/file", new byte[0]));
         assertThat(language).contains(Language.JAVA);
     }
 
@@ -49,7 +50,7 @@ public class FirstMatchMathingStrategyTest {
         LanguageDetectionStrategy two = noopDetectionStrategy(Language.JAVA);
         FirstMatchMathingStrategy mathingStrategy = new FirstMatchMathingStrategy(one, two);
 
-        Optional<Language> language = mathingStrategy.detect("/some/file", new byte[0]);
+        Optional<Language> language = mathingStrategy.detect(new LanguageDetectionContext("", "/some/file", new byte[0]));
         assertThat(language).contains(Language.JAVA);
     }
 
@@ -59,7 +60,7 @@ public class FirstMatchMathingStrategyTest {
         LanguageDetectionStrategy two = noopDetectionStrategy();
         FirstMatchMathingStrategy mathingStrategy = new FirstMatchMathingStrategy(one, two);
 
-        Optional<Language> language = mathingStrategy.detect("/some/file", new byte[0]);
+        Optional<Language> language = mathingStrategy.detect(new LanguageDetectionContext("", "/some/file", new byte[0]));
         assertThat(language).isEmpty();
     }
 
@@ -68,7 +69,7 @@ public class FirstMatchMathingStrategyTest {
         LanguageDetectionStrategy one = noopDetectionStrategy(Language.JAVASCRIPT, Language.TYPESCRIPT);
         FirstMatchMathingStrategy mathingStrategy = new FirstMatchMathingStrategy(one);
 
-        Optional<Language> language = mathingStrategy.detect("/some/file", new byte[0]);
+        Optional<Language> language = mathingStrategy.detect(new LanguageDetectionContext("", "/some/file", new byte[0]));
         assertThat(language).contains(Language.JAVASCRIPT);
     }
 

--- a/spotter-core/src/test/java/com/github/sdorra/spotter/internal/LanguageTests.java
+++ b/spotter-core/src/test/java/com/github/sdorra/spotter/internal/LanguageTests.java
@@ -25,20 +25,15 @@
 package com.github.sdorra.spotter.internal;
 
 import com.github.sdorra.spotter.Language;
-import com.github.sdorra.spotter.internal.LanguageDetectionStrategy;
+import com.github.sdorra.spotter.LanguageDetectionContext;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 final class LanguageTests {
 
@@ -49,7 +44,7 @@ final class LanguageTests {
         URL url = Resources.getResource(resource);
         byte[] content = Resources.toByteArray(url);
 
-        return strategy.detect(resource, content);
+        return strategy.detect(new LanguageDetectionContext("", resource, content));
     }
 
     static void assertLangFromResource(LanguageDetectionStrategy strategy, Language expected, String resource) throws IOException {
@@ -58,17 +53,17 @@ final class LanguageTests {
     }
 
     static void assertLang(LanguageDetectionStrategy strategy, Language expected, String path) {
-        List<Language> languages = strategy.detect(path, new byte[]{});
+        List<Language> languages = strategy.detect(new LanguageDetectionContext("", path, new byte[]{}));
         assertThat(languages).contains(expected);
     }
 
     static void assertNotFound(LanguageDetectionStrategy strategy, String path) {
-        List<Language> languages = strategy.detect(path, new byte[]{});
+        List<Language> languages = strategy.detect(new LanguageDetectionContext("", path, new byte[]{}));
         assertThat(languages).isEmpty();
     }
 
     static LanguageDetectionStrategy noopDetectionStrategy(Language... languages) {
         List<Language> list = Lists.newArrayList(languages);
-        return (path, content) -> list;
+        return context -> list;
     }
 }


### PR DESCRIPTION
Make previous languages available for language detection strategies and
use the content type from content detection to select best matching
language.