### PR TITLE
fix language detection with multiple dot separators in filename

### DIFF
--- a/spotter-core/src/main/java/com/github/sdorra/spotter/internal/ExtensionLanguageDetectionStrategy.java
+++ b/spotter-core/src/main/java/com/github/sdorra/spotter/internal/ExtensionLanguageDetectionStrategy.java
@@ -37,7 +37,7 @@ public class ExtensionLanguageDetectionStrategy extends FilenameBasedLanguageDet
 
     @Override
     protected List<Language> detectByFilename(String filename) {
-        int index = filename.indexOf('.');
+        int index = filename.lastIndexOf('.');
         if (index > 0) {
             String extension = filename.substring(index);
             return Language.getByExtension(extension);

--- a/spotter-core/src/test/java/com/github/sdorra/spotter/internal/ExtensionLanguageDetectionStrategyTest.java
+++ b/spotter-core/src/test/java/com/github/sdorra/spotter/internal/ExtensionLanguageDetectionStrategyTest.java
@@ -41,6 +41,9 @@ public class ExtensionLanguageDetectionStrategyTest {
     public void testDetect() {
         assertLang(strategy, Language.PYTHON,"app.py");
         assertLang(strategy, Language.JAVA,"src/main/com/github/sdorra/App.java");
+        assertLang(strategy, Language.JSON, "dogu/blueprint.json");
+        assertLang(strategy, Language.JSON, "dogu/blueprint-3.1.0-dev.json");
+        assertLang(strategy, Language.JAVASCRIPT, "myData/version.test.js");
         assertNotFound(strategy, "scm-manager.png");
     }
 


### PR DESCRIPTION
Fix ExtensionLanguageDetection if the filename contains multiple dot separators. 